### PR TITLE
Disable Go Releaser's before hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@
 before:
   hooks:
     # You may remove this if you don't use go modules.
-    - cd src/gabo && go mod tidy
+    # - cd src/gabo && go mod tidy
     # you may remove this if you don't need go generate
     # - go generate ./...
 builds:


### PR DESCRIPTION
Disable Go Releaser's before hook
It is not working
Ref: https://github.com/ashishb/gabo/actions/runs/4549716839/jobs/8022063963

```
error=hook failed: cd src/gabo && go mod tidy: exec: "cd": executable file not found in $PATH; output:
```