### PR TITLE
Minor fix to Go Releaser checker

### DIFF
--- a/.github/workflows/check-goreleaser-config.yaml
+++ b/.github/workflows/check-goreleaser-config.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: ${{ matrix.go-version }}
           cache-dependency-path: src/gabo/go.sum
 
       - name: Install Go Releaser


### PR DESCRIPTION
Use Go version provided via `matrix`