### PR TITLE
fix: improve golangci-lint caching

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -51,5 +51,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          # We use cache provided by "actions/setup-go@v4"
+          skip-cache: true
           # Directory containing go.mod file
           working-directory: src/gabo

--- a/src/gabo/internal/generator/golang_lint_generator.go
+++ b/src/gabo/internal/generator/golang_lint_generator.go
@@ -13,6 +13,8 @@ const _goLangLintTask = `
       - name: Run golangci-lint on %s
         uses: golangci/golangci-lint-action@v3
         with:
+          # We use cache provided by "actions/setup-go@v4"
+          skip-cache: true
           # Directory containing go.mod file
           working-directory: "%s"
 `


### PR DESCRIPTION
Use caching provided by `actions/setup-go` action