### PR TITLE
chore: upgrade from Go 1.21 -> Go 1.22

### DIFF
--- a/.github/workflows/check-goreleaser-config.yaml
+++ b/.github/workflows/check-goreleaser-config.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/format-go.yaml
+++ b/.github/workflows/format-go.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/src/gabo/internal/generator/data/check-goreleaser-config.yaml
+++ b/src/gabo/internal/generator/data/check-goreleaser-config.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/src/gabo/internal/generator/data/format-go.yaml
+++ b/src/gabo/internal/generator/data/format-go.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/src/gabo/internal/generator/data/lint-go-incomplete.yaml
+++ b/src/gabo/internal/generator/data/lint-go-incomplete.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         # Without quotes, 1.20 becomes 1.2!
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Both for generation and CI