### PR TITLE
chore: enable sparse-checkout in YAML linter

### DIFF
--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -31,6 +31,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            "./**.yml"
+            "./**.yaml"
+            ".github/workflows/"
+
       - name: Check YAML files with linter
         uses: ibiqlik/action-yamllint@v3
         with:

--- a/src/gabo/internal/generator/data/lint-yaml.yaml
+++ b/src/gabo/internal/generator/data/lint-yaml.yaml
@@ -31,6 +31,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            "**.yml"
+            "**.yaml"
+            ".github/workflows/**.yml"
+            ".github/workflows/**.yaml"
+
       - name: Check YAML files with linter
         uses: ibiqlik/action-yamllint@v3
         with:


### PR DESCRIPTION
This will make YAML linting very efficient for large repositories