### PR TITLE
chore: detect `ruff` as a Python linter as well

### DIFF
--- a/src/gabo/internal/generator/all_options.go
+++ b/src/gabo/internal/generator/all_options.go
@@ -114,7 +114,7 @@ func GetOptions() []Option {
 		},
 		_Option{
 			"Python Linter", "lint-python", newFileMatcher("*.py"),
-			newPatternMatcher("pylint "),
+			newPatternMatcher("pylint ", "ruff "),
 			newGenerator(_lintPythonYaml), "lint-python.yaml",
 		},
 		_Option{


### PR DESCRIPTION
Earlier, only `pylint` was detected as Python linter